### PR TITLE
work with spaces in file name

### DIFF
--- a/ifplatform/ifplatform.dtx
+++ b/ifplatform/ifplatform.dtx
@@ -210,7 +210,7 @@ This work consists of the file  ifplatform.dtx
 %    \end{macrocode}
 % Packages required: (thanks Heiko)
 %    \begin{macrocode}
-\RequirePackage{shellesc,pdftexcmds,catchfile,ifluatex}
+\RequirePackage{shellesc,pdftexcmds,catchfile,ifluatex,xstring}
 %    \end{macrocode}
 % Conditionals we provide:
 %    \begin{macrocode}
@@ -244,6 +244,7 @@ This work consists of the file  ifplatform.dtx
 % For internal stuff later:
 %    \begin{macrocode}
 \edef\ip@file{\jobname.w18}
+\StrSubstitute{\ip@file}{"}{}[\ip@file]
 \newif\if@ip@nix@
 %    \end{macrocode}
 % \begin{macro}{\ifshellescape}


### PR DESCRIPTION
Remove double quotes from `\ip@file` with `\StrSubstitute` from `xstring` package.

I would like to compile a tex file `test 2.tex` which contains:
```
\documentclass{article}
\usepackage{svg}

\begin{document}
Lorem ipsum\dots
\end{document}
```
I make the same call that `latexmk` makes:
```
pdflatex  -synctex=1 -shell-escape -interaction=nonstopmode -file-line-error -recorder -output-directory="/home/user/test dir"  "/home/user/test dir/test 2.tex"
```

Errors including the following occur (line 378):
```
/usr/share/texmf-dist/tex/latex/ifplatform/ifplatform.sty:92: Package catchfile Error: File `"test 2".w18' not found.
```
It seems `\ip@file` evaluates to `"test 2".w18`. I believe this first error is because `sh -c 'uname -s > ""test 2".w18"'` results only in `uname -s > test 2.w18` i.e. `uname -s 2.w18 > test` (inferred from `strace`):
```
uname: extra operand ‘2.w18’
Try 'uname --help' for more information.
```
Other errors such as the following then occur as a byproduct but I don't understand why--would `\@tempa` have a `}` in it? (line 383):
```
/usr/share/texmf-dist/tex/latex/ifplatform/ifplatform.sty:94: Argument of \zap@space has an extra }.
...
```
I am using TeX Live. I also get these errors when using LuaLaTeX with minted.

`latexmk` says `Latexmk: Errors, so I did not complete making targets`. It also retries compilation once more for LuaLatex.

Rather than try to escape the quotes when calling `uname` and so on, I simply removed the quotes from `\ip@file` at the top of `ifplatform.sty` by including `xstring` and using `StrSubstitute` as in this file change.

I confirmed that `test 2.w18` is created and removed during compilation. This change removed all errors when using regular LaTeX and LuaLaTeX with minted.

A cleaner way to fix this may be to instead only replace all `"` with `'` on lines `377` and `379`, but `CatchFile` apparently wipes the two quotation marks either advertently or inadvertently by the time it calls `openat(AT_FDCWD,"/home/user/test dir/test 2.tex",O_RDONLY) = -1 ENOENT (No such file or directory)` and `access`, resulting in `/usr/share/texmf-dist/tex/latex/ifplatform/ifplatform.sty:96: Package catchfile Error: File '"test 2".w18' not found.`. For the case that a user has quotes in their filename, is no point in say only removing the first and last quote if there are spaces in the file name (implying LaTeX added quotes to the jobname), because quotes in a path may create an error from CatchFile anyway.

1. What is the rationale for enclosing the job name in literal quotes within `\jobname`?
2. What is typically the actual effect of these errors aside from messing up `latexmk`? It seems like `minted` is able to use its shell escapes effectively despite them. Is `\linuxtrue` default?
3. Given that other files like `test 2.pdf`, `test 2.aux`, etc. are all named without quotes around the base file name, how do the other subsystems of LaTeX handle the quotes imposed by `\jobname` if they do use `\jobname`; and what do they use to get the file name if not?